### PR TITLE
WIP add pod implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Checking out: https://github.com/babashka/fs.git at bc4bd8efe29e9000c941877b0258
 ## Build
 
 To compile this project, point `GRAALVM_HOME` at your GraalVM distribution and
-then run `script/compile`. Using GraalVM 21.0.0 Java 11 CE is recommended.
+then run `script/compile`. Using GraalVM 21.3.0 Java 11 CE is recommended.
 
 The build requires
 [`clojure`](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools)

--- a/deps.edn
+++ b/deps.edn
@@ -2,9 +2,26 @@
  {org.clojure/clojure          {:mvn/version "1.10.3"}
   org.clojure/tools.deps.alpha {:mvn/version "0.12.1067"}
   org.slf4j/slf4j-jdk14        {:mvn/version "1.7.9"}
-  javax.xml.bind/jaxb-api      {:mvn/version "2.3.1"}}
+  javax.xml.bind/jaxb-api      {:mvn/version "2.3.1"}
+  nrepl/bencode                {:mvn/version "1.1.0"}}
  :paths   ["src" "resources"]
  :aliases {:compile-main
            {:main-opts ["-e" "(compile 'borkdude.tdn.main)"]
             :jvm-opts  ["-Dclojure.compiler.direct-linking=true"]}
-           :compile {:main-opts ["-m" "borkdude.tdn.main"]}}}
+
+           :compile {:main-opts  ["-m" "borkdude.tdn.main"]
+                     :extra-deps {babashka/fs {:mvn/version "0.0.1"}}}
+
+           :test
+           {:extra-paths ["test"]
+            :extra-deps
+            {io.github.cognitect-labs/test-runner
+             {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+             babashka/babashka.pods
+             {:git/url "https://github.com/babashka/babashka.pods"
+              :sha     "de4c3610c9ef3879370d01b7202a9f3a9d056f6e"}}
+            :main-opts   ["-m" "cognitect.test-runner"]
+            :exec-fn     cognitect.test-runner.api/test}
+
+           :run
+           {:main-opts ["-m" "borkdude.tdn.main"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,10 @@
 {:deps
- {org.clojure/clojure {:mvn/version "1.10.2-rc1"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.11.935"}
+ {org.clojure/clojure          {:mvn/version "1.10.3"}
+  org.clojure/tools.deps.alpha {:mvn/version "0.12.1067"}
   org.slf4j/slf4j-jdk14        {:mvn/version "1.7.9"}
   javax.xml.bind/jaxb-api      {:mvn/version "2.3.1"}}
- :paths ["src" "resources"]}
+ :paths   ["src" "resources"]
+ :aliases {:compile-main
+           {:main-opts ["-e" "(compile 'borkdude.tdn.main)"]
+            :jvm-opts  ["-Dclojure.compiler.direct-linking=true"]}
+           :compile {:main-opts ["-m" "borkdude.tdn.main"]}}}

--- a/script/compile
+++ b/script/compile
@@ -12,8 +12,12 @@ fi
 
 "$GRAALVM_HOME/bin/gu" install native-image
 
-export JAVA_HOME=$GRAALVM_HOME
-export PATH=$GRAALVM_HOME/bin:$PATH
+# [ ! -x $GRAALVM_HOME/lib/svm/macros/native-image-configure-launcher ] && \
+#     "$GRAALVM_HOME/bin/native-image" --macro:native-image-configure-launcher && \
+#     chmod +x "$GRAALVM_HOME/lib/svm/macros/native-image-configure-launcher"
+
+export JAVA_HOME="$GRAALVM_HOME"
+export PATH="$GRAALVM_HOME/bin:$GRAALVM_HOME/lib/svm/macros:$PATH"
 
 rm -rf classes
 rm -rf tools-deps-native # should not be necessary, but just in case
@@ -25,7 +29,7 @@ init_at_build_time=$(clojure -X borkdude.tdn.main/init-at-build-time)
 echo "$init_at_build_time"
 sleep 1
 
-script/gen-reflect-config.clj clojure -Scp $(clojure -Spath):classes -M:compile '{:deps {babashka/fs {:mvn/version "0.0.1"}}}'
+script/gen-reflect-config.clj $(clojure -Spath):classes
 
 echo "COMPILING"
 

--- a/script/compile
+++ b/script/compile
@@ -12,10 +12,6 @@ fi
 
 "$GRAALVM_HOME/bin/gu" install native-image
 
-# [ ! -x $GRAALVM_HOME/lib/svm/macros/native-image-configure-launcher ] && \
-#     "$GRAALVM_HOME/bin/native-image" --macro:native-image-configure-launcher && \
-#     chmod +x "$GRAALVM_HOME/lib/svm/macros/native-image-configure-launcher"
-
 export JAVA_HOME="$GRAALVM_HOME"
 export PATH="$GRAALVM_HOME/bin:$GRAALVM_HOME/lib/svm/macros:$PATH"
 
@@ -36,7 +32,7 @@ echo "COMPILING"
 args=(-cp "$(clojure -Spath):classes"
       "-H:Name=$app_name"
       -H:+ReportExceptionStackTraces
-      -H:ReflectionConfigurationFiles=reflect-config-cleaned.json
+      -H:ReflectionConfigurationFiles=reflect-config.json
       "-H:ResourceConfigurationFiles=resources.json"
       -H:+JNI
       "-H:Log=registerResource:"

--- a/script/compile
+++ b/script/compile
@@ -18,14 +18,14 @@ export PATH=$GRAALVM_HOME/bin:$PATH
 rm -rf classes
 rm -rf tools-deps-native # should not be necessary, but just in case
 mkdir classes
-clojure -J-Dclojure.compiler.direct-linking=true -e "(compile 'borkdude.tdn.main)"
+clojure -M:compile-main
 
 init_at_build_time=$(clojure -X borkdude.tdn.main/init-at-build-time)
 
 echo "$init_at_build_time"
 sleep 1
 
-script/gen-reflect-config.clj clojure -Scp $(clojure -Spath):classes -M -m borkdude.tdn.main '{:deps {babashka/fs {:mvn/version "0.0.1"}}}'
+script/gen-reflect-config.clj clojure -Scp $(clojure -Spath):classes -M:compile '{:deps {babashka/fs {:mvn/version "0.0.1"}}}'
 
 echo "COMPILING"
 

--- a/script/gen-reflect-config.clj
+++ b/script/gen-reflect-config.clj
@@ -4,123 +4,30 @@
 ;; Runs a command to determine required config that can not be determined
 ;; statically.
 
-(require '[babashka.process :refer [process]]
-         '[babashka.fs :as fs]
-         '[cheshire.core :as cheshire]
-         '[clojure.string :as str])
+(require '[babashka.process :refer [process]])
 
 (def trace-agent "-agentlib:native-image-agent")
 
-(def trace-agent-env
-  (str trace-agent "=trace-output=trace-file.json"))
-(def config-agent-env
-  (str trace-agent"=config-output-dir=."))
-
-(defn trace [cmd]
-  @(process
-    cmd
-    {:inherit   false
-     :extra-env {"JAVA_TOOL_OPTIONS" trace-agent-env}}))
+(defn trace [args]
+  (let [cmd         (into
+                     ["clojure" "-Scp" (first *command-line-args*) "-M:compile"]
+                     args)
+        trace-agent (str trace-agent "=trace-output=trace-file.json")]
+    @(process
+      cmd
+      {:inherit   false
+       :extra-env {"JAVA_TOOL_OPTIONS" trace-agent}})))
 
 (defn trace->config [config-dir]
   @(process
     ["native-image-configure"
      "generate"
      "--trace-input=trace-file.json"
-     (str "--output-dir=" config-dir)])
-  ;; @(process
-  ;;  trace-cmd
-  ;;  {:inherit   true
-  ;;   :extra-env {"JAVA_TOOL_OPTIONS" config-agent-env}})
-  )
-
-(def trace-cmd
-  ["clojure" "-Scp" (first *command-line-args*) "-M:compile"])
+     (str "--output-dir=" config-dir)]))
 
 
-;; (println "TRACE1")
-;; (trace (into trace-cmd ["deps" "{}"]) )
-(trace (into trace-cmd ["deps" "{}"]) )
-;; (trace->config "config1/")
-(println "TRACE2")
-(trace (into trace-cmd
-             ["create-basis"
-              ;; NOTE adding an s3 dep here would enable s3 support?
-              "{:deps {org.clojure/clojure {:mvn/version \"1.10.3\"}}}"]))
+(trace ["deps" "{}"])
+(trace ["create-basis"
+        ;; NOTE adding an s3 dep here would enable s3 support?
+        "{:deps {org.clojure/clojure {:mvn/version \"1.10.3\"}}}"])
 (trace->config ".")
-
-
-
-;; (println "MERGE")
-
-;; @(process
-;;   ["native-image-configure-launcher"
-;;    "generate"
-;;    "--input-dir=config1/"
-;;    "--input-dir=config2/"
-;;    "--output-dir=./"])
-
-
-
-;; (def trace-json (cheshire/parse-string (slurp "trace-file.json") true))
-
-;; ;; [Z = boolean
-;; ;; [B = byte
-;; ;; [S = short
-;; ;; [I = int
-;; ;; [J = long
-;; ;; [F = float
-;; ;; [D = double
-;; ;; [C = char
-;; ;; [L = any non-primitives(Object)
-
-;; (defn normalize-array-name [n]
-;;   ({"[F" "float[]"
-;;     "[B" "byte[]"
-;;     "[Z" "boolean[]"
-;;     "[C" "char[]"
-;;     "[D" "double[]"
-;;     "[I" "int[]"
-;;     "[J" "long[]"
-;;     "[S" "short[]"} n n))
-
-;; (def ignored (atom #{}))
-;; (def unignored (atom #{}))
-
-;; (defn ignore [{:keys [:tracer :caller_class :function :args] :as _m}]
-;;   (when (= "reflect" tracer)
-;;     (when-let [arg (first args)]
-;;       (let [arg (normalize-array-name arg)]
-;;         (if (and caller_class
-;;                  (or (= "clojure.lang.RT" caller_class)
-;;                      (= "clojure.genclass__init" caller_class)
-;;                      (and (str/starts-with? caller_class "clojure.core$fn")
-;;                           (= "java.sql.Timestamp" arg)))
-;;                  (= "forName" function))
-;;           (swap! ignored conj arg)
-;;           (when (= "clojure.lang.RT" caller_class)
-;;             ;; unignore other reflective calls in clojure.lang.RT
-;;             (swap! unignored conj arg)))))))
-
-;; (run! ignore trace-json)
-
-;; (prn :ignored @ignored)
-;; ;; (prn @unignored)
-
-;; (defn process-1 [{:keys [:name] :as m}]
-;;   (when-not (and (= 1 (count m))
-;;                  (contains? @ignored name)
-;;                  (not (contains? @unignored name)))
-;;     ;; fix bug(?) in automated generated config
-;;     (if (= "java.lang.reflect.Method" name)
-;;       (assoc m :name "java.lang.reflect.AccessibleObject")
-;;       m)))
-
-;; (def config-json (cheshire/parse-string (slurp "reflect-config.json") true))
-
-;; (def cleaned (keep process-1 config-json))
-
-;; (spit "reflect-config-cleaned.json" (cheshire/generate-string cleaned {:pretty true}))
-
-(fs/delete "reflect-config-cleaned.json")
-(fs/copy "reflect-config.json" "reflect-config-cleaned.json")

--- a/script/gen-reflect-config.clj
+++ b/script/gen-reflect-config.clj
@@ -1,73 +1,126 @@
 #!/usr/bin/env bb
+;; Build GraalVM configuration using the native-image-agent.
+
+;; Runs a command to determine required config that can not be determined
+;; statically.
 
 (require '[babashka.process :refer [process]]
+         '[babashka.fs :as fs]
          '[cheshire.core :as cheshire]
          '[clojure.string :as str])
 
-(def trace-cmd *command-line-args*)
+(def trace-agent "-agentlib:native-image-agent")
 
-(def trace-agent-env "-agentlib:native-image-agent=trace-output=trace-file.json")
-(def config-agent-env "-agentlib:native-image-agent=config-output-dir=.")
+(def trace-agent-env
+  (str trace-agent "=trace-output=trace-file.json"))
+(def config-agent-env
+  (str trace-agent"=config-output-dir=."))
 
-@(process trace-cmd {:inherit true :extra-env {"JAVA_TOOL_OPTIONS" trace-agent-env}})
-@(process trace-cmd {:inherit true :extra-env {"JAVA_TOOL_OPTIONS" config-agent-env}})
+(defn trace [cmd]
+  @(process
+    cmd
+    {:inherit   false
+     :extra-env {"JAVA_TOOL_OPTIONS" trace-agent-env}}))
 
-(def trace-json (cheshire/parse-string (slurp "trace-file.json") true))
+(defn trace->config [config-dir]
+  @(process
+    ["native-image-configure"
+     "generate"
+     "--trace-input=trace-file.json"
+     (str "--output-dir=" config-dir)])
+  ;; @(process
+  ;;  trace-cmd
+  ;;  {:inherit   true
+  ;;   :extra-env {"JAVA_TOOL_OPTIONS" config-agent-env}})
+  )
 
-;; [Z = boolean
-;; [B = byte
-;; [S = short
-;; [I = int
-;; [J = long
-;; [F = float
-;; [D = double
-;; [C = char
-;; [L = any non-primitives(Object)
+(def trace-cmd
+  ["clojure" "-Scp" (first *command-line-args*) "-M:compile"])
 
-(defn normalize-array-name [n]
-  ({"[F" "float[]"
-    "[B" "byte[]"
-    "[Z" "boolean[]"
-    "[C" "char[]"
-    "[D" "double[]"
-    "[I" "int[]"
-    "[J" "long[]"
-    "[S" "short[]"} n n))
 
-(def ignored (atom #{}))
-(def unignored (atom #{}))
+;; (println "TRACE1")
+;; (trace (into trace-cmd ["deps" "{}"]) )
+(trace (into trace-cmd ["deps" "{}"]) )
+;; (trace->config "config1/")
+(println "TRACE2")
+(trace (into trace-cmd
+             ["create-basis"
+              ;; NOTE adding an s3 dep here would enable s3 support?
+              "{:deps {org.clojure/clojure {:mvn/version \"1.10.3\"}}}"]))
+(trace->config ".")
 
-(defn ignore [{:keys [:tracer :caller_class :function :args] :as _m}]
-  (when (= "reflect" tracer)
-    (when-let [arg (first args)]
-      (let [arg (normalize-array-name arg)]
-        (if (and caller_class
-                 (or (= "clojure.lang.RT" caller_class)
-                     (= "clojure.genclass__init" caller_class)
-                     (and (str/starts-with? caller_class "clojure.core$fn")
-                          (= "java.sql.Timestamp" arg)))
-                 (= "forName" function))
-          (swap! ignored conj arg)
-          (when (= "clojure.lang.RT" caller_class)
-            ;; unignore other reflective calls in clojure.lang.RT
-            (swap! unignored conj arg)))))))
 
-(run! ignore trace-json)
 
-;; (prn @ignored)
-;; (prn @unignored)
+;; (println "MERGE")
 
-(defn process-1 [{:keys [:name] :as m}]
-  (when-not (and (= 1 (count m))
-                 (contains? @ignored name)
-                 (not (contains? @unignored name)))
-    ;; fix bug(?) in automated generated config
-    (if (= "java.lang.reflect.Method" name)
-      (assoc m :name "java.lang.reflect.AccessibleObject")
-      m)))
+;; @(process
+;;   ["native-image-configure-launcher"
+;;    "generate"
+;;    "--input-dir=config1/"
+;;    "--input-dir=config2/"
+;;    "--output-dir=./"])
 
-(def config-json (cheshire/parse-string (slurp "reflect-config.json") true))
 
-(def cleaned (keep process-1 config-json))
 
-(spit "reflect-config-cleaned.json" (cheshire/generate-string cleaned {:pretty true}))
+;; (def trace-json (cheshire/parse-string (slurp "trace-file.json") true))
+
+;; ;; [Z = boolean
+;; ;; [B = byte
+;; ;; [S = short
+;; ;; [I = int
+;; ;; [J = long
+;; ;; [F = float
+;; ;; [D = double
+;; ;; [C = char
+;; ;; [L = any non-primitives(Object)
+
+;; (defn normalize-array-name [n]
+;;   ({"[F" "float[]"
+;;     "[B" "byte[]"
+;;     "[Z" "boolean[]"
+;;     "[C" "char[]"
+;;     "[D" "double[]"
+;;     "[I" "int[]"
+;;     "[J" "long[]"
+;;     "[S" "short[]"} n n))
+
+;; (def ignored (atom #{}))
+;; (def unignored (atom #{}))
+
+;; (defn ignore [{:keys [:tracer :caller_class :function :args] :as _m}]
+;;   (when (= "reflect" tracer)
+;;     (when-let [arg (first args)]
+;;       (let [arg (normalize-array-name arg)]
+;;         (if (and caller_class
+;;                  (or (= "clojure.lang.RT" caller_class)
+;;                      (= "clojure.genclass__init" caller_class)
+;;                      (and (str/starts-with? caller_class "clojure.core$fn")
+;;                           (= "java.sql.Timestamp" arg)))
+;;                  (= "forName" function))
+;;           (swap! ignored conj arg)
+;;           (when (= "clojure.lang.RT" caller_class)
+;;             ;; unignore other reflective calls in clojure.lang.RT
+;;             (swap! unignored conj arg)))))))
+
+;; (run! ignore trace-json)
+
+;; (prn :ignored @ignored)
+;; ;; (prn @unignored)
+
+;; (defn process-1 [{:keys [:name] :as m}]
+;;   (when-not (and (= 1 (count m))
+;;                  (contains? @ignored name)
+;;                  (not (contains? @unignored name)))
+;;     ;; fix bug(?) in automated generated config
+;;     (if (= "java.lang.reflect.Method" name)
+;;       (assoc m :name "java.lang.reflect.AccessibleObject")
+;;       m)))
+
+;; (def config-json (cheshire/parse-string (slurp "reflect-config.json") true))
+
+;; (def cleaned (keep process-1 config-json))
+
+;; (spit "reflect-config-cleaned.json" (cheshire/generate-string cleaned {:pretty true}))
+
+(fs/delete "reflect-config-cleaned.json")
+(fs/copy "reflect-config.json" "reflect-config-cleaned.json")

--- a/src/borkdude/tdn/cli.clj
+++ b/src/borkdude/tdn/cli.clj
@@ -1,0 +1,70 @@
+(ns borkdude.tdn.cli
+  (:require
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]
+   [clojure.tools.deps.alpha :as deps]))
+
+(def default-repos
+  {"central" {:url "https://repo1.maven.org/maven2/"}
+   "clojars" {:url "https://repo.clojars.org/"}})
+
+(defn usage []
+  (println "tools.deps.edn [ (deps [path])]")
+  nil)
+
+(defn help [args]
+  (println "tools.deps.edn [ (deps [path])]")
+  nil)
+
+(defn slurp-deps
+  ([path]
+   (let [file (io/file path)]
+     (when (.exists file)
+       (deps/slurp-deps file))))
+  ([] (deps/slurp-deps (io/file "deps.edn"))))
+
+(defn create-basis [args]
+  (prn :creat-basis args)
+  (let [arg  (first args)
+        deps (edn/read-string arg)]
+    (if (map? deps)
+      (prn (-> deps
+               (update :mvn/repos (fn [repos]
+                                    (or repos default-repos)))
+               deps/create-basis))
+      (binding [*out* *err*]
+        (throw
+         (ex-info (str"Invalid argument " deps ", expeccted a map") {}))))))
+
+(defn deps [args]
+  (let [arg  (first args)
+        deps (or
+              (slurp-deps arg)
+              (edn/read-string arg))]
+    (prn :deps deps)
+    (if (map? deps)
+      (prn (as-> deps x
+             (update x :mvn/repos (fn [repos]
+                                    (or repos default-repos)))
+             (deps/resolve-deps x nil)
+             (deps/make-classpath-map deps x nil)))
+      (binding [*out* *err*]
+        (throw
+         (ex-info (str"Invalid argument " deps ", expeccted a map") {}))))))
+
+(defn cli [args]
+  (if-let [arg (some-> args first keyword)]
+    (try
+      (case arg
+        :deps           (deps (rest args))
+        :create-basis   (println (create-basis (rest args)))
+        :root-deps      (println (deps/root-deps))
+        :slurp-deps     (println (apply slurp-deps (rest args)))
+        :user-deps-path (println (deps/user-deps-path))
+        :help           (help args)
+        (usage))
+      (catch clojure.lang.ExceptionInfo e
+        (binding [*out* *err*]
+          (println (.getMessage e)))
+        (System/exit 1)))
+    (help args)))

--- a/src/borkdude/tdn/cli.clj
+++ b/src/borkdude/tdn/cli.clj
@@ -9,12 +9,10 @@
    "clojars" {:url "https://repo.clojars.org/"}})
 
 (defn usage []
-  (println "tools.deps.edn [ (deps [path])]")
-  nil)
+  (println "tools.deps.edn [ (deps [path])]"))
 
 (defn help [args]
-  (println "tools.deps.edn [ (deps [path])]")
-  nil)
+  (println "tools.deps.edn [ (deps [path])]"))
 
 (defn slurp-deps
   ([path]
@@ -24,7 +22,6 @@
   ([] (deps/slurp-deps (io/file "deps.edn"))))
 
 (defn create-basis [args]
-  (prn :creat-basis args)
   (let [arg  (first args)
         deps (edn/read-string arg)]
     (if (map? deps)
@@ -41,7 +38,6 @@
         deps (or
               (slurp-deps arg)
               (edn/read-string arg))]
-    (prn :deps deps)
     (if (map? deps)
       (prn (as-> deps x
              (update x :mvn/repos (fn [repos]

--- a/src/borkdude/tdn/main.clj
+++ b/src/borkdude/tdn/main.clj
@@ -1,8 +1,8 @@
 (ns borkdude.tdn.main
   (:require
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.tools.deps.alpha :as deps])
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.tools.deps.alpha :as deps])
   (:gen-class))
 
 #_(require '[clojure.tools.deps.alpha.extensions :as ext]) ;; somehow requiring this namespace as a side effect helps...
@@ -12,17 +12,19 @@
 ;; avoid null pointer
 #_(mvn/make-system)
 
+(def default-repos
+  {"central" {:url "https://repo1.maven.org/maven2/"}
+   "clojars" {:url "https://repo.clojars.org/"}})
+
 (defn -main [& args]
   (mvn/make-system)
-  (let [arg (first args)
+  (let [arg     (first args)
         edn-str (if (.exists (io/file arg))
                   (slurp arg)
                   arg)]
     (prn (-> (edn/read-string edn-str)
              (update :mvn/repos (fn [repos]
-                                  (or repos
-                                      {"central" {:url "https://repo1.maven.org/maven2/"}
-                                       "clojars" {:url "https://repo.clojars.org/"}})))
+                                  (or repos default-repos)))
              (deps/resolve-deps nil)
              (deps/make-classpath nil nil)))))
 

--- a/src/borkdude/tdn/pod.clj
+++ b/src/borkdude/tdn/pod.clj
@@ -1,0 +1,134 @@
+(ns borkdude.tdn.pod
+  (:refer-clojure :exclude [read-string])
+  (:require
+   [clojure.edn :as edn]
+   [clojure.tools.deps.alpha]
+   [clojure.walk :as walk]
+   [bencode.core :as bencode])
+  (:import
+   [java.io PushbackInputStream]))
+
+(set! *warn-on-reflection* true)
+
+(def debug? false)
+
+(defn debug [& strs]
+  (when debug?
+    (binding [*out* *err*]
+      (apply println strs))))
+
+;;; bencode
+
+(def stdin (PushbackInputStream. System/in))
+
+(defn read-bencode []
+  (try (bencode/read-bencode stdin)
+       (catch java.io.EOFException _)))
+
+(defn write-bencode [v]
+  (debug :write-bencode v)
+  (bencode/write-bencode System/out v)
+  (.flush System/out))
+
+(defn read-string [^bytes v]
+  (String. v))
+
+(defn read-keyword [v]
+  (some-> v read-string keyword))
+
+(defn read-symbol [v]
+  (some-> v read-string symbol))
+
+(defn write-map [m]
+  (write-bencode
+   (walk/postwalk
+    (fn ident-to-string [v] (if (ident? v) (name v) v))
+    m)))
+
+;;; Implementation
+
+
+(defmacro dispatch-publics [sym args]
+  (let [publics  (->> (the-ns 'clojure.tools.deps.alpha)
+                      ns-publics
+                      keys
+                      (mapv #(symbol "clojure.tools.deps.alpha" (name %))))
+        args-sym (gensym "args")]
+    `(let [~args-sym ~args
+           sym#      ~sym]
+       (case sym#
+         ~@(reduce
+            (fn [forms s]
+              (into forms
+                    [s `(apply ~s ~args-sym)]))
+            []
+            publics)
+         (throw (ex-info (str "Unknown function: " sym#) {}))))))
+
+(defn invoke [msg]
+  (let [v    (some->> (get msg "var")
+                      read-string
+                      symbol
+                                        ;(symbol "clojure.tools.deps.alpha")
+                      #_resolve)
+        args (some-> (get msg "args") read-string edn/read-string)]
+    (debug :invoke :var v :args args)
+    (dispatch-publics v args)))
+
+(defn public-var-maps [ns-sym]
+  (->> (ns-publics (the-ns ns-sym))
+       keys
+       sort
+       (mapv (partial hash-map :name))))
+
+;;; pod protocol
+
+(def description
+  {:format     :edn
+   :namespaces [{:name 'clojure.tools.deps.alpha
+                 :vars (public-var-maps 'clojure.tools.deps.alpha)}]
+   :opts       {:shutdown {}}})
+
+(defn error-map
+  [message data id]
+  {"ex-message" message
+   "ex-data"    (pr-str data)
+   "id"         id
+   "status"     ["done" "error"]})
+
+(defmacro with-message [[id] & body]
+  `(let [id# ~id]
+     (try
+       (write-bencode
+        {"value"  (pr-str ~@body)
+         "id"     id#
+         "status" ["done"]})
+       (catch Exception e#
+         (debug (str e#))
+         (write-bencode
+          (error-map
+           (ex-message e#)
+           (assoc (ex-data e#) :type (str (class e#)))
+           id#))))))
+
+(defn unknown-op
+  [op id]
+  (write-bencode
+   {"ex-message" "Unknown op"
+    "ex-data"    (pr-str {:op op})
+    "id"         id
+    "status"     ["done" "error"]}))
+
+(defn pod [& _args]
+  (loop []
+    (when-let [msg (read-bencode)]
+      (debug :msg msg)
+      (let [op (some-> (get msg "op") read-keyword)
+            id (or (some-> (get msg "id") read-string) "unknown")]
+        (case op
+          :describe (write-map description)
+          :invoke   (with-message [id]
+                      (invoke msg))
+          :shutdown (System/exit 0)
+          (unknown-op op id))
+        (recur)))))

--- a/test.bb
+++ b/test.bb
@@ -1,0 +1,7 @@
+#!/usr/bin/env bb
+
+(require '[babashka.pods :as pods])
+(pods/load-pod "./tools-deps-native")
+
+(require '[clojure.tools.deps.alpha :as deps])
+(deps/calc-basis {})

--- a/test/borkdude/tdn/pod_test.clj
+++ b/test/borkdude/tdn/pod_test.clj
@@ -1,0 +1,25 @@
+(ns borkdude.tdn.pod-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [babashka.pods.jvm :as pods]))
+
+
+(def pod-spec (if (= "native" (System/getenv "POD_TEST_ENV"))
+                "./tools-deps-native"
+                ["clojure" "-Mrun"]))
+
+(deftest pod-lifecycle-test
+  (testing "pod can be loaded and unloaded"
+    (let [pod-id (pods/load-pod pod-spec)]
+      (is pod-id)
+      (pods/unload-pod pod-id))))
+
+(deftest calc-basis-test
+  (testing "pod can be invoke calc-bais"
+    (let [pod-id (pods/load-pod pod-spec)]
+      (try
+        (let [res (pods/invoke pod-id 'calc-basis [{}])]
+          (is (= {:libs {}, :classpath-roots [], :classpath {}}
+                 res )))
+        (finally
+          (pods/unload-pod pod-id))))))

--- a/test/borkdude/tdn/pod_test.clj
+++ b/test/borkdude/tdn/pod_test.clj
@@ -18,7 +18,7 @@
   (testing "pod can be invoke calc-bais"
     (let [pod-id (pods/load-pod pod-spec)]
       (try
-        (let [res (pods/invoke pod-id 'calc-basis [{}])]
+        (let [res (pods/invoke pod-id 'clojure.tools.deps.alpha/calc-basis [{}])]
           (is (= {:libs {}, :classpath-roots [], :classpath {}}
                  res )))
         (finally


### PR DESCRIPTION
When BABASHKA_POD env var is set, act as a pod.

The pod exposes all clojure.tools.deps.alpha public vars.

The cli is refactored to take an initial function argument.

Update to latest tools.deps.alpha

Also updates to use aliases for main invocation in compile script
