### PR TITLE
fix: intialise *the-dir* at runtime

### DIFF
--- a/reflect-config-manual.json
+++ b/reflect-config-manual.json
@@ -1,0 +1,8 @@
+[{"name":"org.apache.maven.model.Build",
+  "queryAllPublicMethods":true,
+  "methods":[
+    {"name":"getOutputDirectory","parameterTypes":[] },
+    {"name":"getSourceDirectory","parameterTypes":[] },
+    {"name":"getTestOutputDirectory","parameterTypes":[] },
+    {"name":"getTestSourceDirectory","parameterTypes":[] }
+  ]}]

--- a/script/compile
+++ b/script/compile
@@ -33,7 +33,7 @@ echo "COMPILING"
 args=(-cp "$(clojure -Spath):classes"
       "-H:Name=$app_name"
       -H:+ReportExceptionStackTraces
-      -H:ReflectionConfigurationFiles=reflect-config.json
+      -H:ReflectionConfigurationFiles=reflect-config.json,reflect-config-manual.json
       "-H:ResourceConfigurationFiles=resources.json"
       -H:+JNI
       "-H:Log=registerResource:"

--- a/src/borkdude/tdn/pod.clj
+++ b/src/borkdude/tdn/pod.clj
@@ -148,6 +148,7 @@
   (assert (symbol? args-sym) (str args-sym)) ; no need to let bind
   `(binding [clojure.tools.deps.alpha.util.dir/*the-dir*
              (clojure.tools.deps.alpha.util.dir/canonicalize (first ~args-sym))]
+     (debug :dir (clojure.tools.deps.alpha.util.dir/canonicalize (first ~args-sym)))
      (apply ~s (second ~args-sym))))
 
 (defn dispatch* [sym args]


### PR DESCRIPTION
Avoid baking in the build directory as the root value for *the-dir^.

This caused a reflection issue with Build/getTestOutputDirectory (unsure
why), which was fixed by adding a manual reflection config file.

Cleaned up main namespace.